### PR TITLE
Fix Errno::EACCES at startup in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@
 # does not allow server specific settings to be passed down.
 if [ -n "$VIRTUAL_HOST" ]
 then
-  exec fake_sqs --bind 0.0.0.0 --hostname $VIRTUAL_HOST --database=/sqs/database.yml --port 9494 --server thin
+  exec fake_sqs --bind 0.0.0.0 --hostname $VIRTUAL_HOST --database=/messages/sqs/database.yml --port 9494 --server thin
 else
-  exec fake_sqs --bind 0.0.0.0 --database=/sqs/database.yml --port 9494 --server thin
+  exec fake_sqs --bind 0.0.0.0 --database=/messages/sqs/database.yml --port 9494 --server thin
 fi


### PR DESCRIPTION
The fake_sqs gem is unable to create a file under the (non-existent) directory `/sqs`.  This reverts the referenced path for the fake_sqs gem's database file.
