### PR TITLE
Trim down docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM ruby:2.2
+FROM ruby:2.2-alpine
 
-COPY Gemfile /Gemfile
-RUN bundle install
+COPY Gemfile Gemfile.lock /
 
-RUN useradd -u 1000 -M docker \
+RUN apk add --no-cache --virtual .ruby-builddeps \
+      autoconf \
+      g++ \
+      git \
+      make \
+    && bundle install \
+    && apk add --no-cache --virtual .ruby-rundeps \
+      libstdc++ \
+    && apk del .ruby-builddeps
+
+RUN adduser -u 1000 -D -H docker \
   && mkdir -p /messages/sqs \
   && chown docker /messages/sqs
 USER docker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GIT
+  remote: https://github.com/feathj/fake_sqs.git
+  revision: 4535993cc33bbff728076bab61def009537c13c1
+  specs:
+    fake_sqs (0.3.1)
+      builder
+      sinatra
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    daemons (1.2.3)
+    eventmachine (1.2.0.1)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
+    tilt (2.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fake_sqs!
+  thin
+
+BUNDLED WITH
+   1.11.2

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Note: We use thin, because webrick attempts to do a reverse dns lookup on every request
 # which slows the service down big time.  There is a setting to override this, but sinatra


### PR DESCRIPTION
With this change, the docker image size goes from 731MB to 135MB.  This also adds in the `Gemfile.lock` from the most recent image to avoid any changes in dependencies.